### PR TITLE
Implement user registration endpoint (REQ-001) #5

### DIFF
--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -8,6 +8,7 @@ from sqlalchemy import text
 
 from app.config import settings
 from app.database import SessionLocal
+from app.routers import auth_router
 
 # Configure logging
 logging.basicConfig(
@@ -30,6 +31,9 @@ app.add_middleware(
     allow_methods=["*"],
     allow_headers=["*"],
 )
+
+# Include routers
+app.include_router(auth_router)
 
 
 @app.get("/")

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,1 +1,7 @@
-"""\nFastAPI routers for API endpoints.\nRouters are organized by feature/domain.\n"""\n
+"""
+FastAPI routers for API endpoints.
+Routers are organized by feature/domain.
+"""
+from app.routers.auth import router as auth_router
+
+__all__ = ["auth_router"]

--- a/backend/app/routers/auth.py
+++ b/backend/app/routers/auth.py
@@ -1,0 +1,62 @@
+"""
+Authentication router for user registration and login endpoints.
+"""
+import logging
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+from sqlalchemy.exc import IntegrityError
+
+from app.database import get_db
+from app.models.user import User
+from app.schemas.user import UserCreate, UserResponse
+from app.utils.security import hash_password
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/auth", tags=["auth"])
+
+
+@router.post("/register", response_model=UserResponse, status_code=status.HTTP_201_CREATED)
+def register(user_data: UserCreate, db: Session = Depends(get_db)):
+    """
+    Register a new user.
+    
+    - **username**: 3-50 characters, alphanumeric and underscore only
+    - **password**: minimum 8 characters
+    
+    Returns the created user (without password).
+    """
+    # Log registration attempt (never log password)
+    logger.info(f"Registration attempt for username: {user_data.username}")
+    
+    # Check if username already exists
+    existing_user = db.query(User).filter(User.username == user_data.username).first()
+    if existing_user:
+        logger.warning(f"Registration failed: username '{user_data.username}' already exists")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already exists"
+        )
+    
+    # Hash the password
+    password_hash = hash_password(user_data.password)
+    
+    # Create new user
+    new_user = User(
+        username=user_data.username,
+        password_hash=password_hash
+    )
+    
+    try:
+        db.add(new_user)
+        db.commit()
+        db.refresh(new_user)
+        logger.info(f"User registered successfully: {new_user.username} (id: {new_user.id})")
+        return new_user
+    except IntegrityError as e:
+        db.rollback()
+        logger.error(f"Database error during registration: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_409_CONFLICT,
+            detail="Username already exists"
+        )

--- a/backend/tests/conftest.py
+++ b/backend/tests/conftest.py
@@ -3,13 +3,60 @@ Pytest configuration and fixtures for testing.
 """
 import pytest
 from fastapi.testclient import TestClient
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker
+from sqlalchemy.pool import StaticPool
 
 from app.main import app
+from app.database import Base, get_db
+
+
+# Create an in-memory SQLite database for testing
+SQLALCHEMY_DATABASE_URL = "sqlite:///:memory:"
+
+engine = create_engine(
+    SQLALCHEMY_DATABASE_URL,
+    connect_args={"check_same_thread": False},
+    poolclass=StaticPool,
+)
+TestingSessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=engine)
+
+
+def override_get_db():
+    """Override database dependency with test database."""
+    db = TestingSessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
 
 
 @pytest.fixture
 def client():
     """
     Test client fixture for making requests to the FastAPI app.
+    Uses an in-memory SQLite database for isolation.
     """
-    return TestClient(app)
+    # Create tables
+    Base.metadata.create_all(bind=engine)
+    
+    # Override the database dependency
+    app.dependency_overrides[get_db] = override_get_db
+    
+    yield TestClient(app)
+    
+    # Clean up
+    app.dependency_overrides.clear()
+    Base.metadata.drop_all(bind=engine)
+
+
+@pytest.fixture
+def db_session():
+    """
+    Database session fixture for direct database access in tests.
+    """
+    Base.metadata.create_all(bind=engine)
+    db = TestingSessionLocal()
+    yield db
+    db.close()
+    Base.metadata.drop_all(bind=engine)

--- a/backend/tests/test_registration.py
+++ b/backend/tests/test_registration.py
@@ -1,0 +1,224 @@
+"""
+Tests for user registration endpoint.
+"""
+import pytest
+from app.models.user import User
+from app.utils.security import verify_password
+
+
+class TestRegistrationEndpoint:
+    """Tests for POST /api/auth/register endpoint."""
+
+    def test_successful_registration(self, client):
+        """Test successful user registration returns 201 and user data."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "testuser", "password": "password123"}
+        )
+        
+        assert response.status_code == 201
+        data = response.json()
+        assert data["username"] == "testuser"
+        assert "id" in data
+        assert "created_at" in data
+        # Password should never be in response
+        assert "password" not in data
+        assert "password_hash" not in data
+
+    def test_registration_creates_user_in_database(self, client, db_session):
+        """Test that registration actually creates a user in the database."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "dbuser", "password": "password123"}
+        )
+        
+        assert response.status_code == 201
+        
+        # Verify user exists in database
+        user = db_session.query(User).filter(User.username == "dbuser").first()
+        assert user is not None
+        assert user.username == "dbuser"
+
+    def test_password_is_hashed(self, client, db_session):
+        """Test that password is stored as bcrypt hash, not plaintext."""
+        password = "mySecurePassword123"
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "hashtest", "password": password}
+        )
+        
+        assert response.status_code == 201
+        
+        # Get user from database
+        user = db_session.query(User).filter(User.username == "hashtest").first()
+        
+        # Password should not be stored in plaintext
+        assert user.password_hash != password
+        
+        # Password hash should be verifiable
+        assert verify_password(password, user.password_hash) is True
+        
+        # Hash should be bcrypt format (starts with $2)
+        assert user.password_hash.startswith("$2")
+
+    def test_username_stored_lowercase(self, client, db_session):
+        """Test that username is stored in lowercase."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "TestUser", "password": "password123"}
+        )
+        
+        assert response.status_code == 201
+        assert response.json()["username"] == "testuser"
+        
+        # Verify in database
+        user = db_session.query(User).filter(User.username == "testuser").first()
+        assert user is not None
+
+    def test_duplicate_username_returns_409(self, client):
+        """Test that registering with existing username returns 409."""
+        # First registration
+        client.post(
+            "/api/auth/register",
+            json={"username": "duplicate", "password": "password123"}
+        )
+        
+        # Second registration with same username
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "duplicate", "password": "differentpassword"}
+        )
+        
+        assert response.status_code == 409
+        assert "already exists" in response.json()["detail"].lower()
+
+    def test_username_case_insensitive_duplicate(self, client):
+        """Test that username check is case-insensitive (John vs john)."""
+        # First registration
+        client.post(
+            "/api/auth/register",
+            json={"username": "john", "password": "password123"}
+        )
+        
+        # Second registration with different case
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "JOHN", "password": "password123"}
+        )
+        
+        assert response.status_code == 409
+
+    def test_username_too_short_returns_422(self, client):
+        """Test that username less than 3 characters returns validation error."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "ab", "password": "password123"}
+        )
+        
+        assert response.status_code == 422
+
+    def test_username_too_long_returns_422(self, client):
+        """Test that username more than 50 characters returns validation error."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "a" * 51, "password": "password123"}
+        )
+        
+        assert response.status_code == 422
+
+    def test_username_invalid_characters_returns_422(self, client):
+        """Test that username with invalid characters returns validation error."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "test@user", "password": "password123"}
+        )
+        
+        assert response.status_code == 422
+
+    def test_username_with_underscore_allowed(self, client):
+        """Test that username with underscore is allowed."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "test_user", "password": "password123"}
+        )
+        
+        assert response.status_code == 201
+        assert response.json()["username"] == "test_user"
+
+    def test_password_too_short_returns_422(self, client):
+        """Test that password less than 8 characters returns validation error."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "testuser", "password": "short"}
+        )
+        
+        assert response.status_code == 422
+
+    def test_missing_username_returns_422(self, client):
+        """Test that missing username returns validation error."""
+        response = client.post(
+            "/api/auth/register",
+            json={"password": "password123"}
+        )
+        
+        assert response.status_code == 422
+
+    def test_missing_password_returns_422(self, client):
+        """Test that missing password returns validation error."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "testuser"}
+        )
+        
+        assert response.status_code == 422
+
+    def test_empty_body_returns_422(self, client):
+        """Test that empty request body returns validation error."""
+        response = client.post("/api/auth/register", json={})
+        
+        assert response.status_code == 422
+
+    def test_response_does_not_include_password(self, client):
+        """Test that response never includes password or password_hash."""
+        response = client.post(
+            "/api/auth/register",
+            json={"username": "nopassword", "password": "password123"}
+        )
+        
+        assert response.status_code == 201
+        data = response.json()
+        
+        # Check that no password-related fields are in response
+        assert "password" not in data
+        assert "password_hash" not in data
+        assert "hashed_password" not in data
+
+    def test_sql_injection_handled_safely(self, client):
+        """Test that SQL injection attempts are handled safely."""
+        # Try various SQL injection patterns
+        injection_attempts = [
+            "'; DROP TABLE users; --",
+            "1; DELETE FROM users",
+            "admin'--",
+            "1 OR 1=1",
+        ]
+        
+        for injection in injection_attempts:
+            response = client.post(
+                "/api/auth/register",
+                json={"username": injection, "password": "password123"}
+            )
+            # Should either reject with 422 (invalid chars) or succeed without harm
+            assert response.status_code in [201, 422]
+
+    def test_multiple_users_can_register(self, client):
+        """Test that multiple different users can register."""
+        users = ["user1", "user2", "user3"]
+        
+        for username in users:
+            response = client.post(
+                "/api/auth/register",
+                json={"username": username, "password": "password123"}
+            )
+            assert response.status_code == 201
+            assert response.json()["username"] == username


### PR DESCRIPTION
## Summary
Implements the user registration endpoint as specified in issue #5, allowing new users to create accounts.

## Requirements Implemented
- REQ-001: User Registration

## Changes Made

### Auth Router (`backend/app/routers/auth.py`)
- `POST /api/auth/register` endpoint
- Validates username (3-50 chars, alphanumeric + underscore)
- Validates password (minimum 8 characters)
- Hashes password using bcrypt via passlib
- Stores username in lowercase for case-insensitivity
- Returns 201 Created with user data (excluding password)
- Returns 409 Conflict for duplicate username
- Returns 422 Unprocessable Entity for validation errors
- Logs registration attempts (username only, never password)

### Main Application (`backend/app/main.py`)
- Added auth router inclusion
- Endpoint available at `/api/auth/register`

### Test Configuration (`backend/tests/conftest.py`)
- Updated with in-memory SQLite database for test isolation
- Added `db_session` fixture for direct database access in tests

### Registration Tests (`backend/tests/test_registration.py`)
- 17 comprehensive tests covering:
  - Successful registration
  - User created in database
  - Password hashing verification
  - Username stored lowercase
  - Duplicate username (409)
  - Case-insensitive duplicate check
  - Username validation (too short, too long, invalid chars)
  - Username with underscore allowed
  - Password too short validation
  - Missing fields validation
  - Empty body validation
  - Response excludes password
  - SQL injection safety
  - Multiple users can register

## Testing
- [x] 42 tests passing (25 existing + 17 new)
- All registration scenarios covered
- Password hashing verified (bcrypt format)
- SQL injection attempts handled safely

## Acceptance Criteria Verification
- [x] POST /api/auth/register endpoint created
- [x] Accepts JSON body with username and password
- [x] Username validation: 3-50 characters, alphanumeric + underscore, case-insensitive
- [x] Password validation: minimum 8 characters
- [x] Password hashed using bcrypt
- [x] Returns 201 Created on success with user data (no password)
- [x] Returns 409 Conflict if username already exists
- [x] Returns 422 for validation errors
- [x] Username stored in lowercase for consistency
- [x] Never logs or returns password in any form

## API Documentation
The endpoint is automatically documented via FastAPI's OpenAPI:
- Swagger UI: `http://localhost:8000/docs`
- ReDoc: `http://localhost:8000/redoc`

## Security Considerations
- Passwords hashed with bcrypt (never stored in plaintext)
- Password never logged or returned in responses
- SQL injection prevented via SQLAlchemy ORM
- Username enumeration possible (consider generic error in future)

## Rollout Notes
- New endpoint, backward compatible
- Requires database with users table (from PR #12)

Closes #5
Related to #1 (Epic: User Authentication)
Implements REQ-001
Depends on: #4 (PR #12)