### PR TITLE
Merge todo backend CRUD endpoints to dev (Issues #17-#21)

### DIFF
--- a/backend/alembic/versions/20260106_220000_002_create_todo_items_table.py
+++ b/backend/alembic/versions/20260106_220000_002_create_todo_items_table.py
@@ -1,0 +1,48 @@
+"""Create todo_items table
+
+Revision ID: 002
+Revises: 001
+Create Date: 2026-01-06 22:00:00.000000
+
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+
+# revision identifiers, used by Alembic.
+revision: str = '002'
+down_revision: Union[str, None] = '001'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    # Create todo_items table
+    op.create_table(
+        'todo_items',
+        sa.Column('id', sa.Integer(), nullable=False),
+        sa.Column('user_id', sa.Integer(), nullable=False),
+        sa.Column('text', sa.String(500), nullable=False),
+        sa.Column('completed', sa.Boolean(), nullable=False, server_default='false'),
+        sa.Column('created_at', sa.DateTime(timezone=True), server_default=sa.func.now(), nullable=True),
+        sa.Column('updated_at', sa.DateTime(timezone=True), nullable=True),
+        sa.PrimaryKeyConstraint('id'),
+        sa.ForeignKeyConstraint(['user_id'], ['users.id'], ondelete='CASCADE'),
+    )
+    
+    # Create indexes for performance
+    op.create_index('ix_todo_items_id', 'todo_items', ['id'], unique=False)
+    op.create_index('ix_todo_items_user_id', 'todo_items', ['user_id'], unique=False)
+    op.create_index('ix_todo_items_user_completed', 'todo_items', ['user_id', 'completed'], unique=False)
+
+
+def downgrade() -> None:
+    # Drop indexes
+    op.drop_index('ix_todo_items_user_completed', table_name='todo_items')
+    op.drop_index('ix_todo_items_user_id', table_name='todo_items')
+    op.drop_index('ix_todo_items_id', table_name='todo_items')
+    
+    # Drop table
+    op.drop_table('todo_items')

--- a/backend/app/models/__init__.py
+++ b/backend/app/models/__init__.py
@@ -1,7 +1,8 @@
 """
 SQLAlchemy database models.
-All models inherit from Base defined in database.py.
+Models define the structure of database tables.
 """
 from app.models.user import User
+from app.models.todo_item import TodoItem
 
-__all__ = ["User"]
+__all__ = ["User", "TodoItem"]

--- a/backend/app/models/todo_item.py
+++ b/backend/app/models/todo_item.py
@@ -1,0 +1,41 @@
+"""
+SQLAlchemy model for to-do items.
+"""
+from sqlalchemy import Column, Integer, String, Boolean, DateTime, ForeignKey
+from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
+
+from app.database import Base
+
+
+class TodoItem(Base):
+    """
+    To-do item model.
+    
+    Attributes:
+        id: Primary key
+        user_id: Foreign key to users table (owner of the item)
+        text: The to-do item text (max 500 chars)
+        completed: Whether the item is completed (default False)
+        created_at: Timestamp when the item was created
+        updated_at: Timestamp when the item was last updated
+    """
+    __tablename__ = "todo_items"
+    
+    id = Column(Integer, primary_key=True, index=True)
+    user_id = Column(
+        Integer, 
+        ForeignKey("users.id", ondelete="CASCADE"), 
+        nullable=False, 
+        index=True
+    )
+    text = Column(String(500), nullable=False)
+    completed = Column(Boolean, default=False, nullable=False)
+    created_at = Column(DateTime(timezone=True), server_default=func.now())
+    updated_at = Column(DateTime(timezone=True), onupdate=func.now())
+    
+    # Relationship to User model
+    owner = relationship("User", back_populates="todo_items")
+    
+    def __repr__(self):
+        return f"<TodoItem(id={self.id}, user_id={self.user_id}, completed={self.completed})>"

--- a/backend/app/models/user.py
+++ b/backend/app/models/user.py
@@ -1,31 +1,38 @@
 """
-User database model.
-Stores user credentials for authentication.
+SQLAlchemy model for users.
 """
 from sqlalchemy import Column, Integer, String, DateTime
 from sqlalchemy.sql import func
+from sqlalchemy.orm import relationship
 
 from app.database import Base
 
 
 class User(Base):
     """
-    User model for storing authentication credentials.
+    User model for authentication and authorization.
     
     Attributes:
-        id: Primary key, auto-incremented
-        username: Unique username (case-insensitive, stored lowercase)
+        id: Primary key
+        username: Unique username (max 50 chars, stored lowercase)
         password_hash: Bcrypt hashed password
-        created_at: Timestamp when user was created
-        updated_at: Timestamp when user was last updated
+        created_at: Timestamp when the user was created
+        updated_at: Timestamp when the user was last updated
     """
     __tablename__ = "users"
-
+    
     id = Column(Integer, primary_key=True, index=True)
     username = Column(String(50), unique=True, nullable=False, index=True)
     password_hash = Column(String(255), nullable=False)
     created_at = Column(DateTime(timezone=True), server_default=func.now())
     updated_at = Column(DateTime(timezone=True), onupdate=func.now())
-
-    def __repr__(self) -> str:
-        return f"<User(id={self.id}, username='{self.username}')>"
+    
+    # Relationship to TodoItem model (one-to-many)
+    todo_items = relationship(
+        "TodoItem", 
+        back_populates="owner", 
+        cascade="all, delete-orphan"
+    )
+    
+    def __repr__(self):
+        return f"<User(id={self.id}, username={self.username})>"

--- a/backend/app/routers/__init__.py
+++ b/backend/app/routers/__init__.py
@@ -1,7 +1,7 @@
 """
 FastAPI routers for API endpoints.
-Routers are organized by feature/domain.
 """
 from app.routers.auth import router as auth_router
+from app.routers.todos import router as todos_router
 
-__all__ = ["auth_router"]
+__all__ = ["auth_router", "todos_router"]

--- a/backend/app/routers/todos.py
+++ b/backend/app/routers/todos.py
@@ -1,0 +1,158 @@
+"""
+To-do items router for CRUD operations.
+All endpoints require authentication and enforce user ownership.
+"""
+import logging
+from typing import List
+
+from fastapi import APIRouter, Depends, HTTPException, status
+from sqlalchemy.orm import Session
+
+from app.database import get_db
+from app.models.user import User
+from app.models.todo_item import TodoItem
+from app.schemas.todo_item import TodoItemCreate, TodoItemUpdateCompletion, TodoItemResponse
+from app.utils.auth import get_current_user
+
+logger = logging.getLogger(__name__)
+
+router = APIRouter(prefix="/api/todos", tags=["todos"])
+
+
+@router.post("/", response_model=TodoItemResponse, status_code=status.HTTP_201_CREATED)
+async def create_todo_item(
+    todo_data: TodoItemCreate,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Create a new to-do item for the authenticated user.
+    
+    - **text**: 1-500 characters, the to-do item content
+    
+    Returns the created to-do item.
+    """
+    logger.info(f"Creating todo for user_id: {current_user.id}")
+    
+    # Create new todo item
+    new_todo = TodoItem(
+        user_id=current_user.id,
+        text=todo_data.text.strip(),  # Remove leading/trailing whitespace
+        completed=False
+    )
+    
+    db.add(new_todo)
+    db.commit()
+    db.refresh(new_todo)
+    
+    logger.info(f"Todo created: id={new_todo.id} for user_id={current_user.id}")
+    return new_todo
+
+
+@router.get("/", response_model=List[TodoItemResponse])
+async def get_all_todos(
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Get all to-do items for the authenticated user.
+    
+    Returns items in reverse chronological order (newest first).
+    """
+    logger.info(f"Fetching todos for user_id: {current_user.id}")
+    
+    todos = db.query(TodoItem)\
+              .filter(TodoItem.user_id == current_user.id)\
+              .order_by(TodoItem.id.desc())\
+              .all()
+    
+    logger.info(f"Returning {len(todos)} todos for user_id={current_user.id}")
+    return todos
+
+
+@router.patch("/{todo_id}", response_model=TodoItemResponse)
+async def update_todo_completion(
+    todo_id: int,
+    update_data: TodoItemUpdateCompletion,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Update the completion status of a to-do item.
+    
+    Users can only update their own items.
+    
+    - **completed**: Boolean indicating completion status
+    
+    Returns the updated to-do item.
+    """
+    logger.info(f"Updating todo_id={todo_id} for user_id={current_user.id}")
+    
+    # Get the todo item
+    todo = db.query(TodoItem).filter(TodoItem.id == todo_id).first()
+    
+    # Check if todo exists
+    if not todo:
+        logger.warning(f"Todo not found: id={todo_id}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Todo item not found"
+        )
+    
+    # Check authorization (user owns this todo)
+    if todo.user_id != current_user.id:
+        logger.warning(f"Authorization failed: user_id={current_user.id} tried to update todo_id={todo_id}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to update this item"
+        )
+    
+    # Update completion status
+    todo.completed = update_data.completed
+    db.commit()
+    db.refresh(todo)
+    
+    logger.info(f"Todo updated: id={todo_id}, completed={update_data.completed}")
+    return todo
+
+
+@router.delete("/{todo_id}", status_code=status.HTTP_204_NO_CONTENT)
+async def delete_todo_item(
+    todo_id: int,
+    current_user: User = Depends(get_current_user),
+    db: Session = Depends(get_db)
+):
+    """
+    Delete a to-do item permanently.
+    
+    Users can only delete their own items.
+    
+    Returns 204 No Content on success.
+    """
+    logger.info(f"Deleting todo_id={todo_id} for user_id={current_user.id}")
+    
+    # Get the todo item
+    todo = db.query(TodoItem).filter(TodoItem.id == todo_id).first()
+    
+    # Check if todo exists
+    if not todo:
+        logger.warning(f"Todo not found: id={todo_id}")
+        raise HTTPException(
+            status_code=status.HTTP_404_NOT_FOUND,
+            detail="Todo item not found"
+        )
+    
+    # Check authorization (user owns this todo)
+    if todo.user_id != current_user.id:
+        logger.warning(f"Authorization failed: user_id={current_user.id} tried to delete todo_id={todo_id}")
+        raise HTTPException(
+            status_code=status.HTTP_403_FORBIDDEN,
+            detail="Not authorized to delete this item"
+        )
+    
+    # Delete the todo
+    db.delete(todo)
+    db.commit()
+    
+    logger.info(f"Todo deleted: id={todo_id}")
+    return None

--- a/backend/app/schemas/__init__.py
+++ b/backend/app/schemas/__init__.py
@@ -4,6 +4,7 @@ Schemas define the structure of API inputs and outputs.
 """
 from app.schemas.user import UserCreate, UserResponse, UserInDB
 from app.schemas.auth import LoginRequest, LoginResponse, LoginUserInfo
+from app.schemas.todo_item import TodoItemCreate, TodoItemUpdateCompletion, TodoItemResponse
 
 __all__ = [
     "UserCreate", 
@@ -12,4 +13,7 @@ __all__ = [
     "LoginRequest",
     "LoginResponse",
     "LoginUserInfo",
+    "TodoItemCreate",
+    "TodoItemUpdateCompletion",
+    "TodoItemResponse",
 ]

--- a/backend/app/schemas/todo_item.py
+++ b/backend/app/schemas/todo_item.py
@@ -1,0 +1,35 @@
+"""
+Pydantic schemas for to-do item requests and responses.
+"""
+from datetime import datetime
+from typing import Optional
+
+from pydantic import BaseModel, Field
+
+
+class TodoItemCreate(BaseModel):
+    """
+    Schema for creating a new to-do item.
+    """
+    text: str = Field(..., min_length=1, max_length=500, description="To-do item text")
+
+
+class TodoItemUpdateCompletion(BaseModel):
+    """
+    Schema for updating to-do item completion status.
+    """
+    completed: bool = Field(..., description="Completion status")
+
+
+class TodoItemResponse(BaseModel):
+    """
+    Schema for to-do item response.
+    """
+    id: int
+    user_id: int
+    text: str
+    completed: bool
+    created_at: datetime
+    updated_at: Optional[datetime] = None
+    
+    model_config = {"from_attributes": True}

--- a/backend/tests/test_health.py
+++ b/backend/tests/test_health.py
@@ -27,20 +27,12 @@ def test_health_endpoint_structure(client):
     
     # Check overall status exists
     assert "status" in data
-    assert data["status"] in ["healthy", "unhealthy"]
+    assert data["status"] in ["healthy", "degraded", "unhealthy"]
     
     # Check components structure
     assert "components" in data
     assert "api" in data["components"]
     assert "database" in data["components"]
-    
-    # Check API component
-    assert "status" in data["components"]["api"]
-    assert data["components"]["api"]["status"] == "healthy"
-    
-    # Check database component has required fields
-    assert "status" in data["components"]["database"]
-    assert "message" in data["components"]["database"]
 
 
 def test_health_endpoint_api_always_healthy(client):
@@ -49,4 +41,4 @@ def test_health_endpoint_api_always_healthy(client):
     data = response.json()
     
     # If we get a response, API component should be healthy
-    assert data["components"]["api"]["status"] == "healthy"
+    assert data["components"]["api"] == "healthy"

--- a/backend/tests/test_todo_model.py
+++ b/backend/tests/test_todo_model.py
@@ -1,0 +1,186 @@
+"""
+Tests for TodoItem model and schemas.
+"""
+import pytest
+from pydantic import ValidationError
+
+from app.models.todo_item import TodoItem
+from app.models.user import User
+from app.schemas.todo_item import TodoItemCreate, TodoItemUpdateCompletion, TodoItemResponse
+
+
+class TestTodoItemModel:
+    """Tests for TodoItem SQLAlchemy model."""
+
+    def test_todo_item_model_has_required_fields(self):
+        """Test that TodoItem model has all required fields."""
+        assert hasattr(TodoItem, 'id')
+        assert hasattr(TodoItem, 'user_id')
+        assert hasattr(TodoItem, 'text')
+        assert hasattr(TodoItem, 'completed')
+        assert hasattr(TodoItem, 'created_at')
+        assert hasattr(TodoItem, 'updated_at')
+
+    def test_todo_item_model_tablename(self):
+        """Test that TodoItem model has correct table name."""
+        assert TodoItem.__tablename__ == "todo_items"
+
+    def test_todo_item_repr(self, db_session):
+        """Test TodoItem string representation."""
+        # Create a user first
+        user = User(username="testuser", password_hash="hashedpassword")
+        db_session.add(user)
+        db_session.commit()
+        
+        todo = TodoItem(user_id=user.id, text="Test todo", completed=False)
+        db_session.add(todo)
+        db_session.commit()
+        
+        repr_str = repr(todo)
+        assert "TodoItem" in repr_str
+        assert str(todo.id) in repr_str
+        assert str(user.id) in repr_str
+
+    def test_todo_item_can_be_created(self, db_session):
+        """Test that TodoItem can be created and saved."""
+        user = User(username="todouser", password_hash="hashedpassword")
+        db_session.add(user)
+        db_session.commit()
+        
+        todo = TodoItem(user_id=user.id, text="Buy groceries", completed=False)
+        db_session.add(todo)
+        db_session.commit()
+        
+        assert todo.id is not None
+        assert todo.user_id == user.id
+        assert todo.text == "Buy groceries"
+        assert todo.completed is False
+        assert todo.created_at is not None
+
+    def test_todo_item_completed_defaults_to_false(self, db_session):
+        """Test that completed defaults to False."""
+        user = User(username="defaultuser", password_hash="hashedpassword")
+        db_session.add(user)
+        db_session.commit()
+        
+        todo = TodoItem(user_id=user.id, text="Test default")
+        db_session.add(todo)
+        db_session.commit()
+        
+        assert todo.completed is False
+
+    def test_todo_item_relationship_to_user(self, db_session):
+        """Test foreign key relationship to User works."""
+        user = User(username="reluser", password_hash="hashedpassword")
+        db_session.add(user)
+        db_session.commit()
+        
+        todo = TodoItem(user_id=user.id, text="Related todo")
+        db_session.add(todo)
+        db_session.commit()
+        
+        # Test relationship from todo to user
+        assert todo.owner.id == user.id
+        assert todo.owner.username == "reluser"
+        
+        # Test relationship from user to todos
+        assert len(user.todo_items) == 1
+        assert user.todo_items[0].text == "Related todo"
+
+    def test_cascade_delete_removes_todos(self, db_session):
+        """Test that deleting user deletes their todos."""
+        user = User(username="cascadeuser", password_hash="hashedpassword")
+        db_session.add(user)
+        db_session.commit()
+        
+        todo1 = TodoItem(user_id=user.id, text="Todo 1")
+        todo2 = TodoItem(user_id=user.id, text="Todo 2")
+        db_session.add_all([todo1, todo2])
+        db_session.commit()
+        
+        # Get todo ids before deletion
+        todo_ids = [todo1.id, todo2.id]
+        
+        # Delete the user
+        db_session.delete(user)
+        db_session.commit()
+        
+        # Verify todos are deleted
+        remaining_todos = db_session.query(TodoItem).filter(
+            TodoItem.id.in_(todo_ids)
+        ).all()
+        assert len(remaining_todos) == 0
+
+    def test_user_can_have_multiple_todos(self, db_session):
+        """Test that a user can have multiple to-do items."""
+        user = User(username="multiuser", password_hash="hashedpassword")
+        db_session.add(user)
+        db_session.commit()
+        
+        todos = [
+            TodoItem(user_id=user.id, text=f"Todo {i}")
+            for i in range(5)
+        ]
+        db_session.add_all(todos)
+        db_session.commit()
+        
+        assert len(user.todo_items) == 5
+
+
+class TestTodoItemSchemas:
+    """Tests for TodoItem Pydantic schemas."""
+
+    def test_todo_item_create_valid(self):
+        """Test valid TodoItemCreate schema."""
+        data = TodoItemCreate(text="Buy milk")
+        assert data.text == "Buy milk"
+
+    def test_todo_item_create_text_required(self):
+        """Test that text is required."""
+        with pytest.raises(ValidationError):
+            TodoItemCreate()
+
+    def test_todo_item_create_text_min_length(self):
+        """Test minimum text length (1 character)."""
+        with pytest.raises(ValidationError):
+            TodoItemCreate(text="")
+
+    def test_todo_item_create_text_max_length(self):
+        """Test maximum text length (500 characters)."""
+        with pytest.raises(ValidationError):
+            TodoItemCreate(text="x" * 501)
+
+    def test_todo_item_create_text_at_max_length(self):
+        """Test text at exactly max length is valid."""
+        data = TodoItemCreate(text="x" * 500)
+        assert len(data.text) == 500
+
+    def test_todo_item_update_completion_valid(self):
+        """Test valid TodoItemUpdateCompletion schema."""
+        data = TodoItemUpdateCompletion(completed=True)
+        assert data.completed is True
+        
+        data = TodoItemUpdateCompletion(completed=False)
+        assert data.completed is False
+
+    def test_todo_item_update_completion_required(self):
+        """Test that completed is required."""
+        with pytest.raises(ValidationError):
+            TodoItemUpdateCompletion()
+
+    def test_todo_item_response_from_model(self, db_session):
+        """Test TodoItemResponse can be created from model."""
+        user = User(username="respuser", password_hash="hashedpassword")
+        db_session.add(user)
+        db_session.commit()
+        
+        todo = TodoItem(user_id=user.id, text="Response test", completed=True)
+        db_session.add(todo)
+        db_session.commit()
+        
+        response = TodoItemResponse.model_validate(todo)
+        assert response.id == todo.id
+        assert response.user_id == user.id
+        assert response.text == "Response test"
+        assert response.completed is True
+        assert response.created_at is not None

--- a/backend/tests/test_todos.py
+++ b/backend/tests/test_todos.py
@@ -1,0 +1,564 @@
+"""
+Tests for to-do item CRUD endpoints.
+"""
+import pytest
+from app.models.todo_item import TodoItem
+from app.models.user import User
+
+
+class TestTodosEndpoints:
+    """Tests for /api/todos endpoints."""
+
+    def _register_and_login(self, client, username="testuser", password="password123"):
+        """Helper to register a user and get their token."""
+        client.post(
+            "/api/auth/register",
+            json={"username": username, "password": password}
+        )
+        response = client.post(
+            "/api/auth/login",
+            json={"username": username, "password": password}
+        )
+        return response.json()
+
+    def _get_auth_header(self, token: str) -> dict:
+        """Helper to create Authorization header."""
+        return {"Authorization": f"Bearer {token}"}
+
+
+class TestCreateTodo(TestTodosEndpoints):
+    """Tests for POST /api/todos endpoint (Issue #18)."""
+
+    def test_authenticated_user_can_create_todo(self, client):
+        """Test that authenticated user can create a todo item."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        response = client.post(
+            "/api/todos/",
+            json={"text": "Buy groceries"},
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 201
+        data = response.json()
+        assert data["text"] == "Buy groceries"
+        assert data["completed"] is False
+        assert "id" in data
+        assert "created_at" in data
+
+    def test_created_todo_has_correct_user_id(self, client):
+        """Test that created todo has correct user_id."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        user_id = login_data["user"]["id"]
+        
+        response = client.post(
+            "/api/todos/",
+            json={"text": "Test todo"},
+            headers=self._get_auth_header(token)
+        )
+        
+        data = response.json()
+        assert data["user_id"] == user_id
+
+    def test_text_is_trimmed(self, client):
+        """Test that text is trimmed (leading/trailing whitespace removed)."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        response = client.post(
+            "/api/todos/",
+            json={"text": "  Trimmed text  "},
+            headers=self._get_auth_header(token)
+        )
+        
+        data = response.json()
+        assert data["text"] == "Trimmed text"
+
+    def test_empty_text_returns_422(self, client):
+        """Test that empty text returns validation error."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        response = client.post(
+            "/api/todos/",
+            json={"text": ""},
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 422
+
+    def test_text_over_500_chars_returns_422(self, client):
+        """Test that text over 500 chars returns validation error."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        response = client.post(
+            "/api/todos/",
+            json={"text": "x" * 501},
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 422
+
+    def test_unauthenticated_request_returns_403(self, client):
+        """Test that unauthenticated request returns 403."""
+        response = client.post(
+            "/api/todos/",
+            json={"text": "Test todo"}
+        )
+        
+        assert response.status_code == 403
+
+    def test_created_todo_defaults_to_not_completed(self, client):
+        """Test that created todo defaults to completed=false."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        response = client.post(
+            "/api/todos/",
+            json={"text": "New todo"},
+            headers=self._get_auth_header(token)
+        )
+        
+        data = response.json()
+        assert data["completed"] is False
+
+    def test_multiple_todos_can_be_created(self, client):
+        """Test that multiple todos can be created by same user."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        for i in range(3):
+            response = client.post(
+                "/api/todos/",
+                json={"text": f"Todo {i}"},
+                headers=self._get_auth_header(token)
+            )
+            assert response.status_code == 201
+
+
+class TestGetAllTodos(TestTodosEndpoints):
+    """Tests for GET /api/todos endpoint (Issue #19)."""
+
+    def test_authenticated_user_can_retrieve_todos(self, client):
+        """Test that authenticated user can retrieve their todos."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create some todos
+        for i in range(3):
+            client.post(
+                "/api/todos/",
+                json={"text": f"Todo {i}"},
+                headers=self._get_auth_header(token)
+            )
+        
+        # Get todos
+        response = client.get(
+            "/api/todos/",
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert len(data) == 3
+
+    def test_todos_sorted_newest_first(self, client):
+        """Test that todos are sorted newest first."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create todos in order
+        texts = ["First", "Second", "Third"]
+        for text in texts:
+            client.post(
+                "/api/todos/",
+                json={"text": text},
+                headers=self._get_auth_header(token)
+            )
+        
+        # Get todos
+        response = client.get(
+            "/api/todos/",
+            headers=self._get_auth_header(token)
+        )
+        
+        data = response.json()
+        # Newest should be first
+        assert data[0]["text"] == "Third"
+        assert data[2]["text"] == "First"
+
+    def test_user_only_sees_their_own_todos(self, client):
+        """Test that user only sees their own todos (data isolation)."""
+        # Create user 1 with todos
+        login1 = self._register_and_login(client, "user1")
+        token1 = login1["access_token"]
+        client.post(
+            "/api/todos/",
+            json={"text": "User 1 todo"},
+            headers=self._get_auth_header(token1)
+        )
+        
+        # Create user 2 with todos
+        login2 = self._register_and_login(client, "user2")
+        token2 = login2["access_token"]
+        client.post(
+            "/api/todos/",
+            json={"text": "User 2 todo"},
+            headers=self._get_auth_header(token2)
+        )
+        
+        # User 1 should only see their todo
+        response = client.get(
+            "/api/todos/",
+            headers=self._get_auth_header(token1)
+        )
+        data = response.json()
+        assert len(data) == 1
+        assert data[0]["text"] == "User 1 todo"
+
+    def test_returns_empty_array_for_user_with_no_todos(self, client):
+        """Test that returns empty array for user with no todos."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        response = client.get(
+            "/api/todos/",
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 200
+        assert response.json() == []
+
+    def test_unauthenticated_request_returns_403(self, client):
+        """Test that unauthenticated request returns 403."""
+        response = client.get("/api/todos/")
+        assert response.status_code == 403
+
+
+class TestUpdateTodoCompletion(TestTodosEndpoints):
+    """Tests for PATCH /api/todos/{id} endpoint (Issue #20)."""
+
+    def test_user_can_update_own_todo_completion(self, client):
+        """Test that user can update their own todo completion status."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create a todo
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "Test todo"},
+            headers=self._get_auth_header(token)
+        )
+        todo_id = create_response.json()["id"]
+        
+        # Update completion status
+        response = client.patch(
+            f"/api/todos/{todo_id}",
+            json={"completed": True},
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 200
+        data = response.json()
+        assert data["completed"] is True
+
+    def test_toggle_from_false_to_true(self, client):
+        """Test toggle from false to true."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "Test todo"},
+            headers=self._get_auth_header(token)
+        )
+        todo_id = create_response.json()["id"]
+        
+        response = client.patch(
+            f"/api/todos/{todo_id}",
+            json={"completed": True},
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.json()["completed"] is True
+
+    def test_toggle_from_true_to_false(self, client):
+        """Test toggle from true to false."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create and mark complete
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "Test todo"},
+            headers=self._get_auth_header(token)
+        )
+        todo_id = create_response.json()["id"]
+        
+        client.patch(
+            f"/api/todos/{todo_id}",
+            json={"completed": True},
+            headers=self._get_auth_header(token)
+        )
+        
+        # Now toggle back to false
+        response = client.patch(
+            f"/api/todos/{todo_id}",
+            json={"completed": False},
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.json()["completed"] is False
+
+    def test_404_for_nonexistent_todo(self, client):
+        """Test 404 for non-existent todo ID."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        response = client.patch(
+            "/api/todos/99999",
+            json={"completed": True},
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Todo item not found"
+
+    def test_403_when_updating_another_users_todo(self, client):
+        """Test 403 when trying to update another user's todo."""
+        # User 1 creates a todo
+        login1 = self._register_and_login(client, "user1")
+        token1 = login1["access_token"]
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "User 1 todo"},
+            headers=self._get_auth_header(token1)
+        )
+        todo_id = create_response.json()["id"]
+        
+        # User 2 tries to update it
+        login2 = self._register_and_login(client, "user2")
+        token2 = login2["access_token"]
+        
+        response = client.patch(
+            f"/api/todos/{todo_id}",
+            json={"completed": True},
+            headers=self._get_auth_header(token2)
+        )
+        
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to update this item"
+
+    def test_401_for_unauthenticated_request(self, client):
+        """Test 403 for unauthenticated request."""
+        response = client.patch(
+            "/api/todos/1",
+            json={"completed": True}
+        )
+        
+        assert response.status_code == 403
+
+    def test_text_and_other_fields_remain_unchanged(self, client):
+        """Test that text and other fields remain unchanged after update."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "Original text"},
+            headers=self._get_auth_header(token)
+        )
+        todo = create_response.json()
+        todo_id = todo["id"]
+        
+        # Update completion
+        response = client.patch(
+            f"/api/todos/{todo_id}",
+            json={"completed": True},
+            headers=self._get_auth_header(token)
+        )
+        
+        updated = response.json()
+        assert updated["text"] == "Original text"
+        assert updated["id"] == todo_id
+
+
+class TestDeleteTodo(TestTodosEndpoints):
+    """Tests for DELETE /api/todos/{id} endpoint (Issue #21)."""
+
+    def test_user_can_delete_own_todo(self, client):
+        """Test that user can delete their own todo."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create a todo
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "To be deleted"},
+            headers=self._get_auth_header(token)
+        )
+        todo_id = create_response.json()["id"]
+        
+        # Delete it
+        response = client.delete(
+            f"/api/todos/{todo_id}",
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 204
+
+    def test_deleted_todo_is_removed_from_database(self, client, db_session):
+        """Test that deleted todo is removed from database."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create a todo
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "To be deleted"},
+            headers=self._get_auth_header(token)
+        )
+        todo_id = create_response.json()["id"]
+        
+        # Delete it
+        client.delete(
+            f"/api/todos/{todo_id}",
+            headers=self._get_auth_header(token)
+        )
+        
+        # Verify it's gone from database
+        todo = db_session.query(TodoItem).filter(TodoItem.id == todo_id).first()
+        assert todo is None
+
+    def test_subsequent_get_returns_404(self, client):
+        """Test that subsequent GET request for deleted todo returns 404."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create a todo
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "To be deleted"},
+            headers=self._get_auth_header(token)
+        )
+        todo_id = create_response.json()["id"]
+        
+        # Delete it
+        client.delete(
+            f"/api/todos/{todo_id}",
+            headers=self._get_auth_header(token)
+        )
+        
+        # Try to update deleted todo
+        response = client.patch(
+            f"/api/todos/{todo_id}",
+            json={"completed": True},
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 404
+
+    def test_404_for_nonexistent_todo(self, client):
+        """Test 404 for non-existent todo ID."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        response = client.delete(
+            "/api/todos/99999",
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 404
+        assert response.json()["detail"] == "Todo item not found"
+
+    def test_403_when_deleting_another_users_todo(self, client):
+        """Test 403 when trying to delete another user's todo."""
+        # User 1 creates a todo
+        login1 = self._register_and_login(client, "user1")
+        token1 = login1["access_token"]
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "User 1 todo"},
+            headers=self._get_auth_header(token1)
+        )
+        todo_id = create_response.json()["id"]
+        
+        # User 2 tries to delete it
+        login2 = self._register_and_login(client, "user2")
+        token2 = login2["access_token"]
+        
+        response = client.delete(
+            f"/api/todos/{todo_id}",
+            headers=self._get_auth_header(token2)
+        )
+        
+        assert response.status_code == 403
+        assert response.json()["detail"] == "Not authorized to delete this item"
+
+    def test_401_for_unauthenticated_request(self, client):
+        """Test 403 for unauthenticated request."""
+        response = client.delete("/api/todos/1")
+        assert response.status_code == 403
+
+    def test_users_other_todos_remain_unaffected(self, client):
+        """Test that user's other todos remain unaffected after deletion."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create multiple todos
+        todo_ids = []
+        for i in range(3):
+            response = client.post(
+                "/api/todos/",
+                json={"text": f"Todo {i}"},
+                headers=self._get_auth_header(token)
+            )
+            todo_ids.append(response.json()["id"])
+        
+        # Delete the middle one
+        client.delete(
+            f"/api/todos/{todo_ids[1]}",
+            headers=self._get_auth_header(token)
+        )
+        
+        # Get remaining todos
+        response = client.get(
+            "/api/todos/",
+            headers=self._get_auth_header(token)
+        )
+        
+        data = response.json()
+        assert len(data) == 2
+        remaining_ids = [t["id"] for t in data]
+        assert todo_ids[0] in remaining_ids
+        assert todo_ids[2] in remaining_ids
+        assert todo_ids[1] not in remaining_ids
+
+    def test_idempotency_deleting_already_deleted_returns_404(self, client):
+        """Test that deleting already-deleted todo returns 404."""
+        login_data = self._register_and_login(client)
+        token = login_data["access_token"]
+        
+        # Create and delete a todo
+        create_response = client.post(
+            "/api/todos/",
+            json={"text": "To be deleted"},
+            headers=self._get_auth_header(token)
+        )
+        todo_id = create_response.json()["id"]
+        
+        client.delete(
+            f"/api/todos/{todo_id}",
+            headers=self._get_auth_header(token)
+        )
+        
+        # Try to delete again
+        response = client.delete(
+            f"/api/todos/{todo_id}",
+            headers=self._get_auth_header(token)
+        )
+        
+        assert response.status_code == 404


### PR DESCRIPTION
## Summary
Merges the todo backend CRUD implementation from the feature branch to dev.

This consolidates the backend todo functionality including:
- Todo item database model and schema (#17)
- Create todo endpoint (#18)
- Get all todos endpoint (#19)
- Update todo completion endpoint (#20)
- Delete todo endpoint (#21)

## Context
The frontend tasks (Issues #22, #23) depend on these backend endpoints being available on dev.

Related to Epic #2 (To-Do List Management)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Implements to-do management end-to-end in the backend.
> 
> - Adds authenticated CRUD endpoints at `/api/todos` (create, list, update completion, delete) with ownership enforcement in `app/routers/todos.py`
> - Introduces `TodoItem` SQLAlchemy model and relationships; updates `User` with `todo_items` back-population
> - New Alembic migration `alembic/versions/20260106_220000_002_create_todo_items_table.py` creating `todo_items` with indexes and FK cascade
> - Adds Pydantic schemas (`TodoItemCreate`, `TodoItemUpdateCompletion`, `TodoItemResponse`) and exports in `schemas/__init__.py`
> - Wires router in `app/main.py`; switches to FastAPI lifespan handler; simplifies `/health` response to `components.api` string and supports `degraded` status
> - Adds tests for health response, model behavior, and endpoint flows (auth, sorting, isolation, 403/404 cases)
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit eab8cb8794dc28bfd2054369c89fbe17c25e59f8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->