### PR TITLE
Fix database status display on home page #32

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -18,8 +18,8 @@ function Home() {
     const checkHealth = async () => {
       try {
         const health = await healthCheck()
-        setApiStatus(health.components?.api?.status || health.status || 'unknown')
-        setDbStatus(health.components?.database?.status || 'unknown')
+        setApiStatus(health.components?.api || health.status || 'unknown')
+        setDbStatus(health.components?.database || 'unknown')
       } catch (error) {
         console.error('Health check failed:', error)
         setApiStatus('error')

--- a/frontend/src/App.test.jsx
+++ b/frontend/src/App.test.jsx
@@ -1,7 +1,11 @@
+/**
+ * Tests for the main App component.
+ */
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 import App from './App'
 
+// Mock the API service
 vi.mock('./services/api', () => ({
   healthCheck: vi.fn(),
   default: {
@@ -27,8 +31,8 @@ describe('App', () => {
       healthCheck.mockResolvedValue({
         status: 'healthy',
         components: {
-          api: { status: 'healthy' },
-          database: { status: 'healthy' },
+          api: 'healthy',
+          database: 'healthy',
         },
       })
 
@@ -40,8 +44,8 @@ describe('App', () => {
       healthCheck.mockResolvedValue({
         status: 'healthy',
         components: {
-          api: { status: 'healthy' },
-          database: { status: 'healthy' },
+          api: 'healthy',
+          database: 'healthy',
         },
       })
 
@@ -68,8 +72,8 @@ describe('App', () => {
       healthCheck.mockResolvedValue({
         status: 'healthy',
         components: {
-          api: { status: 'healthy' },
-          database: { status: 'healthy' },
+          api: 'healthy',
+          database: 'healthy',
         },
       })
 
@@ -83,8 +87,8 @@ describe('App', () => {
       healthCheck.mockResolvedValue({
         status: 'healthy',
         components: {
-          api: { status: 'healthy' },
-          database: { status: 'healthy' },
+          api: 'healthy',
+          database: 'healthy',
         },
       })
 
@@ -92,10 +96,28 @@ describe('App', () => {
 
       expect(screen.queryByRole('button', { name: /logout/i })).not.toBeInTheDocument()
     })
+
+    it('displays unhealthy database status correctly', async () => {
+      healthCheck.mockResolvedValue({
+        status: 'degraded',
+        components: {
+          api: 'healthy',
+          database: 'unhealthy',
+        },
+      })
+
+      render(<App />)
+
+      await waitFor(() => {
+        expect(screen.getByText('healthy')).toBeInTheDocument()
+        expect(screen.getByText('unhealthy')).toBeInTheDocument()
+      })
+    })
   })
 
   describe('Authenticated state', () => {
     beforeEach(() => {
+      // Set up authenticated state in localStorage
       localStorage.setItem('token', 'test-token')
       localStorage.setItem('user', JSON.stringify({ id: 1, username: 'testuser' }))
     })
@@ -104,8 +126,8 @@ describe('App', () => {
       healthCheck.mockResolvedValue({
         status: 'healthy',
         components: {
-          api: { status: 'healthy' },
-          database: { status: 'healthy' },
+          api: 'healthy',
+          database: 'healthy',
         },
       })
 
@@ -120,8 +142,8 @@ describe('App', () => {
       healthCheck.mockResolvedValue({
         status: 'healthy',
         components: {
-          api: { status: 'healthy' },
-          database: { status: 'healthy' },
+          api: 'healthy',
+          database: 'healthy',
         },
       })
 
@@ -136,8 +158,8 @@ describe('App', () => {
       healthCheck.mockResolvedValue({
         status: 'healthy',
         components: {
-          api: { status: 'healthy' },
-          database: { status: 'healthy' },
+          api: 'healthy',
+          database: 'healthy',
         },
       })
 
@@ -153,8 +175,8 @@ describe('App', () => {
       healthCheck.mockResolvedValue({
         status: 'healthy',
         components: {
-          api: { status: 'healthy' },
-          database: { status: 'healthy' },
+          api: 'healthy',
+          database: 'healthy',
         },
       })
 


### PR DESCRIPTION
## Summary
Fixes the "Database status: unknown" bug on the home page.

## Root Cause
The frontend was incorrectly parsing the health check response:
- **Before**: `health.components?.database?.status` → returns `undefined`
- **After**: `health.components?.database` → returns `"healthy"`

The backend returns component statuses as direct string values, not objects with a `.status` property.

## Changes
- **frontend/src/App.jsx**: Fixed lines 21-22 to correctly access health status values
- **frontend/src/App.test.jsx**: Updated mocked health responses to match actual backend format; added test for unhealthy database status

## Testing
- [x] Database status displays "healthy" when connected
- [x] API status continues to display correctly
- [x] Error state handled when health check fails
- [x] Test added for unhealthy database status display

## Acceptance Criteria Met
- [x] Database status displays correctly as "healthy" when database is connected
- [x] Database status displays "unhealthy" when database has issues
- [x] Database status displays "error" when health check fails
- [x] Fix maintains compatibility with existing backend response format
- [x] No regression in API status display

Closes #32